### PR TITLE
Update model save load methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build
 dist
 *.egg-info
+.vscode
+.pytest_cache
+datasets/
+.python-version
 
 # Sphinx documentation
 docs/build/

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ We summarize the frequently used APIs of FASTopic here. It's easier for you to l
 | Get top words and probabilities of a topic    |  `.get_topic(topic_idx=10)` |
 | Get topic weights over the input dataset    |  `.get_topic_weights()` |
 | Get topic activity over time    |  `.topic_activity_over_time(time_slices)` |
-| Save model    |  `.save("./model.zip")` |
-| Load model    |  `.load("./model.zip")` |
+| Save model    |  `.save(path=path, model_name='test_model')` |
+| Load model    |  `.from_pretrained(f"{path}/test_model/fastopic.pkl")` |
 
 
 ### Visualization

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as f:
 with open('README.md') as f:
     readme = f.read()
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 DESCRIPTION = 'FASTopic'
 LONG_DESCRIPTION = """
     FASTopic is a topic modeling package.

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,4 +1,4 @@
-import numpy as np
+from numpy.testing import assert_almost_equal
 import pytest
 
 import sys
@@ -25,9 +25,12 @@ def test(cache_path, num_topics):
     model = FASTopic(num_topics=num_topics, epochs=1)
     docs = dataset.train_texts
     model.fit_transform(docs)
+    beta = model.get_beta()
 
-    path = f"{cache_path}/model.zip"
-    model.save_model(path)
+    path = f"{cache_path}/models/"
+    model.save(path=path, model_name='test_model')
 
-    new_model = FASTopic(num_topics=num_topics)
-    new_model.load_model(path)
+    new_model = FASTopic().from_pretrained(f"{path}/test_model/fastopic.pkl")
+    new_beta = new_model.get_beta()
+
+    assert_almost_equal(beta, new_beta)


### PR DESCRIPTION
This PR is related to the following issue https://github.com/BobXWu/FASTopic/issues/4.

Here we update the `save_model()` and `load_model()` methods by `save()` and `from_pretrained()` repectively.

Before only pytorch model weights were saved and load. Now the `FASTopic` object itself is serialized along with its own model weights. 